### PR TITLE
Place SECRET_KEY in dev.py and local.py only

### DIFF
--- a/project_name/project_name/settings/base.py
+++ b/project_name/project_name/settings/base.py
@@ -92,7 +92,6 @@ DATABASES = {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': '{{ project_name }}',
         'USER': 'postgres',
-        'PASSWORD': '',
         'HOST': '',  # Set to empty string for localhost.
         'PORT': '',  # Set to empty string for default.
         'CONN_MAX_AGE': 600,  # number of seconds database connections should persist for

--- a/project_name/project_name/settings/dev.py
+++ b/project_name/project_name/settings/dev.py
@@ -5,9 +5,9 @@ DEBUG = True
 TEMPLATE_DEBUG = True
 
 SECRET_KEY = '{{ secret_key }}'
+DATABASES['default']['PASSWORD'] = ''
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
 
 try:
     from .local import *

--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -1,6 +1,6 @@
 from .base import *
 
-# Do not set SECRET_KEY or LDAP password or any other sensitive data here.
+# Do not set SECRET_KEY, Postgres or LDAP password or any other sensitive data here.
 # Instead, create a local.py file on the server.
 
 # Disable debug mode


### PR DESCRIPTION
While fiddling with settings files I noticed it might make sense to enforce setting `SECRET_KEY` and other confidential data in `dev.py` and `local.py` but not in `base.py`.

This will make sure: 
- Developers share the default settings by using `dev.py`
- Production server data will never be committed (neither in `base.py` nor in `production.py`) but instead set in its `local.py`

Does this make sense at all?
