### PR TITLE
Add Celery support and supporting files. Fixes #21

### DIFF
--- a/project_name/home/tasks.py
+++ b/project_name/home/tasks.py
@@ -1,0 +1,25 @@
+"""
+Sample tasks file.
+Will fallback to a simple task decorator that returns the original function.
+"""
+
+# The following will check to see if we can import task from celery -
+# if not then we definitely haven't installed it.
+# Taken from wagtail core
+try:
+    from celery.decorators import task
+    NO_CELERY = False
+except:
+    NO_CELERY = True
+
+# However, we could have installed celery for other projects. So we will also
+# check if we have defined the BROKER_URL setting. If not then definitely we
+# haven't configured it.
+if NO_CELERY or not hasattr(settings, 'BROKER_URL'):
+    # So if we enter here we will define a different "task" decorator that
+    # just returns the original function and sets its delay attribute to
+    # point to the original function: This way, the actual callee
+    # function (task_function()) will be called instead of task_function.delay()
+    def task(f):
+        f.delay = f
+        return f

--- a/project_name/home/tasks.py
+++ b/project_name/home/tasks.py
@@ -3,19 +3,14 @@ Sample tasks file.
 Will fallback to a simple task decorator that returns the original function.
 """
 
-# The following will check to see if we can import task from celery -
-# if not then we definitely haven't installed it.
-# Taken from wagtail core
-try:
-    from celery.decorators import task
-    NO_CELERY = False
-except:
-    NO_CELERY = True
+from django.conf import settings
 
-# However, we could have installed celery for other projects. So we will also
-# check if we have defined the BROKER_URL setting. If not then definitely we
+from celery.decorators import task
+
+# We could have installed celery for other projects.
+# Check if we have defined the BROKER_URL setting. If not then definitely we
 # haven't configured it.
-if NO_CELERY or not hasattr(settings, 'BROKER_URL'):
+if not hasattr(settings, 'BROKER_URL'):
     # So if we enter here we will define a different "task" decorator that
     # just returns the original function and sets its delay attribute to
     # point to the original function: This way, the actual callee

--- a/project_name/project_name/celery.py
+++ b/project_name/project_name/celery.py
@@ -14,7 +14,7 @@ from celery import Celery
 from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.production")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.dev")
 
 app = Celery("{{ project_name }}")
 

--- a/project_name/project_name/celery.py
+++ b/project_name/project_name/celery.py
@@ -1,0 +1,22 @@
+"""
+Celery config for {{ project_name }} project.
+
+For more information on this file, see
+http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html
+
+Run your celery worker(s) as `celery -A {{ project_name }} worker --loglevel=info`
+"""
+
+from __future__ import absolute_import
+
+import os
+from celery import Celery
+from django.conf import settings
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings.production")
+
+app = Celery("{{ project_name }}")
+
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/project_name/project_name/settings/base.py
+++ b/project_name/project_name/settings/base.py
@@ -184,3 +184,12 @@ WAGTAILSEARCH_BACKENDS = {
         'INDEX': '{{ project_name }}',
     },
 }
+
+# Celery settings
+# When you have multiple sites using the same Redis server,
+# specify a different Redis DB. e.g. redis://localhost/5
+
+BROKER_URL = 'redis://'
+
+CELERY_SEND_TASK_ERROR_EMAILS = True
+CELERYD_LOG_COLOR = False

--- a/project_name/project_name/settings/dev.py
+++ b/project_name/project_name/settings/dev.py
@@ -9,6 +9,11 @@ DATABASES['default']['PASSWORD'] = ''
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+# Process all tasks synchronoysly.
+# Helpful for local development and running tests
+CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+CELERY_ALWAYS_EAGER = True
+
 try:
     from .local import *
 except ImportError:

--- a/project_name/project_name/settings/dev.py
+++ b/project_name/project_name/settings/dev.py
@@ -9,7 +9,7 @@ DATABASES['default']['PASSWORD'] = ''
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-# Process all tasks synchronoysly.
+# Process all tasks synchronously.
 # Helpful for local development and running tests
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 CELERY_ALWAYS_EAGER = True

--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -18,7 +18,7 @@ COMPRESS_CSS_FILTERS = [
 
 
 # Add HTML minification
-MIDDLEWARE_CLASSES +=(
+MIDDLEWARE_CLASSES += (
     'htmlmin.middleware.HtmlMinifyMiddleware',
     'htmlmin.middleware.MarkRequestMiddleware',
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ elasticsearch==1.2.0
 django-redis-cache==0.13.0
 wagtail==0.8.4
 django-htmlmin==0.7.0
+celery==3.1.17
 
 # Developer tools
 Fabric==1.9.0


### PR DESCRIPTION
Added Celery support (see #21)

Follows recommendations from http://celery.readthedocs.org/en/latest/django/first-steps-with-django.html and http://www.revsys.com/12days/async-workers-celery/

Provides a note about multiple sites using the same Redis backend.