### PR TITLE
Support use_cdn, http_cache.

### DIFF
--- a/project_name/project_name/settings/production.py
+++ b/project_name/project_name/settings/production.py
@@ -44,6 +44,26 @@ if 'PRIMARY_HOST' in env:
 if 'SERVER_EMAIL' in env:
     SERVER_EMAIL = env['SERVER_EMAIL']
 
+if 'CACHE_PURGE_URL' in env:
+    INSTALLED_APPS += ( 'wagtail.contrib.wagtailfrontendcache', )
+    WAGTAILFRONTENDCACHE = {
+        'default': {
+            'BACKEND': 'wagtail.contrib.wagtailfrontendcache.backends.HTTPBackend',
+            'LOCATION': env['CACHE_PURGE_URL'],
+        },
+    }
+
+if 'STATIC_URL' in env:
+    STATIC_URL = env['STATIC_URL']
+
+if 'STATIC_DIR' in env:
+    STATIC_DIR = env['STATIC_DIR']
+
+if 'MEDIA_URL' in env:
+    MEDIA_URL = env['MEDIA_URL']
+
+if 'MEDIA_DIR' in env:
+    MEDIA_URL = env['MEDIA_DIR']
 
 # Database
 


### PR DESCRIPTION
```
http_cache: if $CFG_CACHE_PURGE_URL is set, configure frontendcache to
purge pages on edit.  We ignore $CFG_CACHE_PURGE_BACKEND (hardcoding it
to HTTPBackend) because that's a project-specific setting, not a
property of the deployment environment.

$CFG_CACHE_PURGE_URL is always a full URL (not protocol-relative), but
beyond that the application shouldn't make any assumptions about its
content.  In particular, it may be either http or https.  Usually it
will be the same as the site URL, but that isn't guaranteed (for
example, under some Varnish configurations it might be http://localhost/,
but we're unlikely to deploy any more applications behind Varnish, in
favour of nginx).

use_cdn: honour environment variables for static and media locations:

- $CFG_STATIC_DIR
- $CFG_STATIC_URL
- $CFG_MEDIA_DIR
- $CFG_MEDIA_URL

Currently, we only set the $..._URL forms, not the $..._DIR forms, but
that will be changing soon as we move to NFS for media storage.

The URLs can have any form, but currently they're either relative URLs
(i.e., '/static/'), or protocol-relative URLs with a hostname, e.g.
'//d1e2lt5cd4cosj.cloudfront.net/tbxwagtail/static/'.  In either case
they will always end with a '/'.

In future this might change (for example, we might add a protocol), so
as with the cache purge URL, no assumptions should be made about their
format.
```
